### PR TITLE
Support Python 3.9

### DIFF
--- a/comicfn2dict/parse.py
+++ b/comicfn2dict/parse.py
@@ -1,4 +1,5 @@
 """Parse comic book archive names using the simple 'parse' parser."""
+from __future__ import annotations
 
 from calendar import month_abbr
 from copy import copy

--- a/comicfn2dict/unparse.py
+++ b/comicfn2dict/unparse.py
@@ -1,4 +1,5 @@
 """Unparse comic filenames."""
+from __future__ import annotations
 
 from calendar import month_abbr
 from collections.abc import Callable, Mapping, Sequence

--- a/poetry.lock
+++ b/poetry.lock
@@ -963,5 +963,5 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "4515a96c7b7f52c54723925326999a5565d78f6c3c2f25adbd137dd7994ac4ce"
+python-versions = "^3.9"
+content-hash = "39af5e6f01d257e457a710d8b126cbc467e520d7e2ad5942d3610fb503d5ce3a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["*/**/*~"]
 include = []
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 neovim = "^0.3.1"


### PR DESCRIPTION
ComicTagger still supports Python3.9 until eol [next year] and can't use this as a dependency unless it supports 3.9 comictagger/comictagger#618.

[next year]: https://devguide.python.org/versions/