### PR TITLE
Reduce radon complexity in cross_validate_comicbox.py

### DIFF
--- a/bin/cross_validate_comicbox.py
+++ b/bin/cross_validate_comicbox.py
@@ -22,6 +22,7 @@ import argparse
 import json
 import sys
 from collections import Counter
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,18 @@ _DEFAULT_DIRS = (
     Path.home() / "Milliways/Comics/slimlib",
 )
 _COMPARE_KEYS = ("series", "issue", "year", "volume", "title", "publisher")
+# Each output key, with the nested-dict path that holds it in the comicbox
+# metadata. The last element is a tuple of sub-keys tried in order — the first
+# truthy one is used. ``None`` in the path means the value is at the top level
+# of the comicbox dict.
+_GROUND_TRUTH_SPECS: tuple[tuple[str, str | None, tuple[str, ...]], ...] = (
+    ("series", "series", ("name",)),
+    ("issue", "issue", ("number", "name")),
+    ("year", "date", ("year",)),
+    ("volume", "volume", ("number",)),
+    ("title", None, ("title",)),
+    ("publisher", "publisher", ("name",)),
+)
 
 
 def _comicbox_metadata(path: Path) -> dict[str, Any] | None:
@@ -66,21 +79,30 @@ def _normalize(key: str, value: Any) -> str:
     return str(value).strip()
 
 
+def _extract_truth_value(
+    cb: dict[str, Any], parent: str | None, subkeys: tuple[str, ...]
+) -> Any:
+    """Pull a single value out of the nested comicbox dict, or None."""
+    if parent is None:
+        return cb.get(subkeys[0])
+    section = cb.get(parent)
+    if not isinstance(section, dict):
+        return None
+    for sub in subkeys:
+        if (value := section.get(sub)) is not None:
+            return value
+    return None
+
+
 def _ground_truth(cb: dict[str, Any]) -> dict[str, str]:
+    """Extract the fields we can compare against the parser, normalised."""
     out: dict[str, str] = {}
-    if (series := cb.get("series")) and isinstance(series, dict):
-        out["series"] = _normalize("series", series.get("name"))
-    if (issue := cb.get("issue")) and isinstance(issue, dict):
-        out["issue"] = _normalize("issue", issue.get("number") or issue.get("name"))
-    if (date := cb.get("date")) and isinstance(date, dict) and date.get("year"):
-        out["year"] = _normalize("year", date["year"])
-    if (volume := cb.get("volume")) and isinstance(volume, dict):
-        out["volume"] = _normalize("volume", volume.get("number"))
-    if title := cb.get("title"):
-        out["title"] = _normalize("title", title)
-    if (publisher := cb.get("publisher")) and isinstance(publisher, dict):
-        out["publisher"] = _normalize("publisher", publisher.get("name"))
-    return {k: v for k, v in out.items() if v}
+    for key, parent, subkeys in _GROUND_TRUTH_SPECS:
+        if (value := _extract_truth_value(cb, parent, subkeys)) is not None:
+            normalized = _normalize(key, value)
+            if normalized:
+                out[key] = normalized
+    return out
 
 
 def _parser_output(filename: str) -> dict[str, str]:
@@ -88,35 +110,34 @@ def _parser_output(filename: str) -> dict[str, str]:
     return {k: _normalize(k, raw.get(k)) for k in _COMPARE_KEYS if raw.get(k)}
 
 
-def _diff(truth: dict[str, str], parsed: dict[str, str]) -> dict[str, tuple[str, str]]:
-    # Comicbox stores colon-joined names like "Stillwater: The Escape" in the
-    # series field; if the parser split that into series + title, treat it as
-    # an equivalent match for the series check (and skip title since comicbox
-    # didn't supply one).
+def _is_colon_split_equivalent(truth: dict[str, str], parsed: dict[str, str]) -> bool:
+    """True when parser series+title matches a colon-joined comicbox series."""
     truth_series = truth.get("series", "")
     parsed_series = parsed.get("series", "")
     parsed_title = parsed.get("title", "")
-    if (
+    return (
         ":" in truth_series
-        and parsed_series
-        and parsed_title
+        and bool(parsed_series)
+        and bool(parsed_title)
         and truth_series == f"{parsed_series}: {parsed_title}"
-    ):
-        truth = {k: v for k, v in truth.items() if k not in ("series", "title")}
-        parsed = {k: v for k, v in parsed.items() if k not in ("series", "title")}
+    )
 
-    diff: dict[str, tuple[str, str]] = {}
-    for key in _COMPARE_KEYS:
-        t = truth.get(key, "")
-        p = parsed.get(key, "")
-        if not t or not p:
-            # Both must have a value for a meaningful diff (filename can't tell
-            # us about title pulled from internal tags, etc.)
-            continue
-        if t == p:
-            continue
-        diff[key] = (t, p)
-    return diff
+
+def _diff(truth: dict[str, str], parsed: dict[str, str]) -> dict[str, tuple[str, str]]:
+    # Treat a parser series/title split as equivalent to comicbox's colon-
+    # joined "X: Y" series, so the field-by-field comparison doesn't flag it.
+    if _is_colon_split_equivalent(truth, parsed):
+        ignore = {"series", "title"}
+        truth = {k: v for k, v in truth.items() if k not in ignore}
+        parsed = {k: v for k, v in parsed.items() if k not in ignore}
+
+    # A meaningful diff requires both sides to have a value; comicbox often
+    # supplies fields the filename can't (title from internal tags, etc.).
+    return {
+        key: (truth[key], parsed[key])
+        for key in _COMPARE_KEYS
+        if truth.get(key) and parsed.get(key) and truth[key] != parsed[key]
+    }
 
 
 def _walk(dirs: list[Path]) -> list[Path]:
@@ -129,7 +150,19 @@ def _walk(dirs: list[Path]) -> list[Path]:
     return paths
 
 
-def main() -> int:
+@dataclass
+class _Tally:
+    """Accumulates per-file processing results."""
+
+    diffs: list[dict[str, Any]] = field(default_factory=list)
+    skipped: int = 0
+    untagged: int = 0
+    matched: int = 0
+    field_disagreements: Counter[str] = field(default_factory=Counter)
+    field_examples: dict[str, list[tuple[str, str, str]]] = field(default_factory=dict)
+
+
+def _build_argparser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("dirs", nargs="*", type=Path, default=list(_DEFAULT_DIRS))
     ap.add_argument("--limit", type=int, default=0, help="cap files processed")
@@ -139,61 +172,67 @@ def main() -> int:
         default=Path("/tmp/cfn_analysis/cb_diff.json"),
         help="JSON output file with per-file diffs",
     )
-    args = ap.parse_args()
+    return ap
 
+
+def _process_path(path: Path, tally: _Tally) -> None:
+    """Parse one archive, record either a match or a per-field disagreement."""
+    cb = _comicbox_metadata(path)
+    if cb is None:
+        tally.skipped += 1
+        return
+    truth = _ground_truth(cb)
+    if not truth.get("series"):
+        tally.untagged += 1
+        return
+    parsed = _parser_output(path.name)
+    diff = _diff(truth, parsed)
+    if not diff:
+        tally.matched += 1
+        return
+    tally.diffs.append(
+        {"file": path.name, "truth": truth, "parsed": parsed, "diff": diff}
+    )
+    for key, (t, p) in diff.items():
+        tally.field_disagreements[key] += 1
+        tally.field_examples.setdefault(key, []).append((path.name, t, p))
+
+
+def _print_report(tally: _Tally, total: int, out_path: Path) -> None:
+    print()
+    print(f"Total scanned : {total}")
+    print(f"  comicbox skipped: {tally.skipped}")
+    print(f"  untagged        : {tally.untagged}")
+    print(f"  parser matched  : {tally.matched}")
+    print(f"  disagreements   : {len(tally.diffs)}")
+    print()
+    print("Disagreements by field:")
+    for key, n in tally.field_disagreements.most_common():
+        print(f"  {key:10s} {n:5d}")
+        for fn, t, p in tally.field_examples[key][:5]:
+            print(f"    {fn}")
+            print(f"        truth : {t!r}")
+            print(f"        parsed: {p!r}")
+    print()
+    print(f"Full diff written to {out_path}")
+
+
+def main() -> int:
+    args = _build_argparser().parse_args()
     paths = _walk(args.dirs)
     if args.limit:
         paths = paths[: args.limit]
     print(f"Scanning {len(paths)} files...")
 
-    diffs: list[dict[str, Any]] = []
-    skipped = 0
-    untagged = 0
-    matched = 0
-    field_disagreements: Counter[str] = Counter()
-    field_examples: dict[str, list[tuple[str, str, str]]] = {}
-
+    tally = _Tally()
     for i, path in enumerate(paths):
         if i and i % 200 == 0:
             print(f"  {i}/{len(paths)}...")
-        cb = _comicbox_metadata(path)
-        if cb is None:
-            skipped += 1
-            continue
-        truth = _ground_truth(cb)
-        if not truth.get("series"):
-            untagged += 1
-            continue
-        parsed = _parser_output(path.name)
-        diff = _diff(truth, parsed)
-        if not diff:
-            matched += 1
-            continue
-        diffs.append(
-            {"file": path.name, "truth": truth, "parsed": parsed, "diff": diff}
-        )
-        for key, (t, p) in diff.items():
-            field_disagreements[key] += 1
-            field_examples.setdefault(key, []).append((path.name, t, p))
+        _process_path(path, tally)
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
-    args.out.write_text(json.dumps(diffs, indent=2, ensure_ascii=False))
-    print()
-    print(f"Total scanned : {len(paths)}")
-    print(f"  comicbox skipped: {skipped}")
-    print(f"  untagged        : {untagged}")
-    print(f"  parser matched  : {matched}")
-    print(f"  disagreements   : {len(diffs)}")
-    print()
-    print("Disagreements by field:")
-    for key, n in field_disagreements.most_common():
-        print(f"  {key:10s} {n:5d}")
-        for fn, t, p in field_examples[key][:5]:
-            print(f"    {fn}")
-            print(f"        truth : {t!r}")
-            print(f"        parsed: {p!r}")
-    print()
-    print(f"Full diff written to {args.out}")
+    args.out.write_text(json.dumps(tally.diffs, indent=2, ensure_ascii=False))
+    _print_report(tally, len(paths), args.out)
     return 0
 
 


### PR DESCRIPTION
## Summary

Pure refactor to clear the three rank-C complexity warnings from `bin/cross_validate_comicbox.py`. Script behaviour and output format are unchanged.

```
Before:
    F 69:0  _ground_truth - C
    F 91:0  _diff         - C
    F 132:0 main          - C

After:
    F _diff               - B   (down from C)
    F _ground_truth       - A
    F main                - A
    + helpers / dataclass - A
```

## Changes

- **`_ground_truth`**: replaced six near-identical field-extraction blocks with a small `_GROUND_TRUTH_SPECS` table and an `_extract_truth_value` helper that walks it.
- **`_diff`**: split the colon-equivalent fast-path into a named predicate (`_is_colon_split_equivalent`) and reduced the field-comparison loop to a dict comprehension.
- **`main`**: extracted `_Tally` (per-file accumulator dataclass), `_build_argparser`, `_process_path` (single-file workflow), and `_print_report`. `main` is now a short driver.

## Test plan

- [x] `uv run radon cc --min C bin/cross_validate_comicbox.py` — no output (clean)
- [x] `uv run complexipy bin/cross_validate_comicbox.py` — no function over 15
- [x] `uv run ruff check bin/cross_validate_comicbox.py` — clean
- [x] `uv run pytest tests/` — 113 passed, 1 skipped
- [x] 100-file cross-validation run reports the same numbers as before the refactor (98 matched, 2 disagreements on the same `Powers Bureau` cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)