### PR TITLE
Add support for Sweet Shop kebab-case filenames

### DIFF
--- a/comicfn2dict/parse.py
+++ b/comicfn2dict/parse.py
@@ -18,6 +18,7 @@ from comicfn2dict.regex import (
     DASH_SEPARATOR_RE,
     ISSUE_BEGIN_RE,
     ISSUE_END_RE,
+    ISSUE_KEYWORD_RE,
     ISSUE_LETTER_RE,
     ISSUE_NUMBER_RE,
     ISSUE_WITH_COUNT_RE,
@@ -167,6 +168,14 @@ class ComicFilenameParser:
             # Letter-only issues like "#Omega" or "#Alpha" — only fires when
             # no digit-bearing issue regex matched.
             self._parse_items(ISSUE_LETTER_RE)
+        if "issue" not in self.metadata:
+            # "issue" as an explicit keyword, e.g. Sweet Shop "series-issue-1.pdf".
+            # When the entire path is hyphen-delimited (no spaces), also convert
+            # the remaining hyphens to spaces so the series name round-trips correctly.
+            _all_hyphens = " " not in self._unparsed_path
+            self._parse_items(ISSUE_KEYWORD_RE, first_only=True)
+            if "issue" in self.metadata and _all_hyphens:
+                self._unparsed_path = self._unparsed_path.replace("-", " ").strip()
         self._log("After Issue")
 
     def _parse_volume(self) -> None:

--- a/comicfn2dict/regex.py
+++ b/comicfn2dict/regex.py
@@ -203,6 +203,10 @@ ISSUE_BEGIN_RE: Pattern = re_compile(r"((^|\/)\(?" + _ISSUE_RE_EXP + r"\)?[\/|\s
 # Letter-only issue tokens explicitly marked with '#' (e.g. "#Omega",
 # "#Alpha"). The '#' prefix is required so we don't grab series words.
 ISSUE_LETTER_RE: Pattern = re_compile(r"\(?#(?P<issue>[A-Za-z]+)\)?")
+# "issue" as an explicit word/hyphen-delimited keyword, e.g. "series-issue-1.pdf"
+# or "Series Name Issue 12". The leading [-\s] is consumed to avoid leaving an
+# orphan separator in the token.
+ISSUE_KEYWORD_RE: Pattern = re_compile(r"[-\s]issue[-\s]+(?P<issue>\d+(?:\.\d+)?)")
 
 # Volume
 _VOLUME_COUNT_RE_EXP = r"\(of\s*(?P<volume_count>\d+)\)"

--- a/tests/comic_filenames.py
+++ b/tests/comic_filenames.py
@@ -849,6 +849,17 @@ FNS.update(
             "year": "2010",
             "series": "Fox-Hare",
         },
+        # Sweet Shop PDF file.
+        "radiant-black-issue-1.pdf": {
+            "ext": "pdf",
+            "issue": "1",
+            "series": "radiant black",
+        },
+        "criminal-issue-1.pdf": {
+            "ext": "pdf",
+            "issue": "1",
+            "series": "criminal",
+        },
     }
 )
 


### PR DESCRIPTION
## Summary

[Sweet Shop](https://sweetshop.app/) offers download backups that use a distinctive kebab-case filename convention, where words are separated by hyphens and the issue number is preceded by the literal word `issue`. For example:

`radiant-black-issue-1.pdf`
`criminal-issue-1.pdf`

## Changes

- Add `ISSUE_KEYWORD_RE` regex that matches the literal word `issue` followed by a number (e.g. `series-issue-1.pdf`), used by the Sweet Shop comic store's naming convention.
- Wire the new regex into the parse pipeline after letter-only issue matching; when the entire path is hyphen-delimited (no spaces), convert remaining hyphens to spaces so the series name is recovered correctly (e.g. `radiant-black` → `radiant black`).
- Add two test fixtures covering this format (`radiant-black-issue-1.pdf`, `criminal-issue-1.pdf`).

